### PR TITLE
fix(nginx): add default_server and new server name

### DIFF
--- a/docker/docusaurus.conf
+++ b/docker/docusaurus.conf
@@ -2,7 +2,7 @@ server {
        listen 80 default_server;
        listen [::]:80 default_server;
 
-       server_name docs.csquare.run docs.csquare.app;
+       server_name docs.csquare.run;
 
        root /var/www/docs.csquare.run;
        index index.html;

--- a/docker/docusaurus.conf
+++ b/docker/docusaurus.conf
@@ -1,8 +1,8 @@
 server {
-       listen 80;
-       listen [::]:80;
+       listen 80 default_server;
+       listen [::]:80 default_server;
 
-       server_name docs.csquare.run;
+       server_name docs.csquare.run docs.csquare.app;
 
        root /var/www/docs.csquare.run;
        index index.html;


### PR DESCRIPTION
Since we are moving to ` docs.csquare.app`, we need to add it to the `server_name` field.

Also, we add `default_server` to route to the default server.